### PR TITLE
fixed minor bug in example_saas_project urlconf

### DIFF
--- a/example_saas_project/urls.py
+++ b/example_saas_project/urls.py
@@ -16,5 +16,5 @@ urlpatterns = patterns('',
 
     # Uncomment the next line to enable the admin:
     # url(r'^admin/', include(admin.site.urls)),
-    url(r'^billing/', include(billing.urls)),
+    url(r'^billing/', include('billing.urls')),
 )


### PR DESCRIPTION
updated example_saas_project urlconf's include to a string to fix "'module' object has no attribute 'urls'" error
